### PR TITLE
Fix warning message due to inappropriate use of AudioTrack.write()

### DIFF
--- a/library/src/main/jni/openslmediaplayer/source/AudioTrackStream.cpp
+++ b/library/src/main/jni/openslmediaplayer/source/AudioTrackStream.cpp
@@ -520,7 +520,6 @@ int32_t AudioTrackStream::sinkWriterThreadLoopFloatByteBuffer(JNIEnv *env) noexc
 #endif
 
     const int32_t write_result = track_->write(env, bb.get(), bb.size(), AudioTrack::WRITE_BLOCKING);
-    track_->write(env, bb.get(), bb.size(), AudioTrack::WRITE_BLOCKING);
 
     if (write_result != bb.size()) {
         return play_result;


### PR DESCRIPTION
Warning message:
> E/android.media.AudioTrack: AudioTrack.write() called with invalid size (38400) value

NOTE: This commit does not fix the entire of the issue #26, but it just fix
the trivial warning message bug.